### PR TITLE
Kafka 0.9.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ val sparkVersion = "1.6.0"
 val scalatraVersion = "2.3.1"
 val jettyVersion = "9.2.5.v20141112"
 val apacheHttpVersion = "4.3.3"
-val kafkaVersion = "0.8.2.2"
+val kafkaVersion = "0.9.0.1"
 val airlineVersion = "0.7"
 
 def dependOnDruid(artifact: String) = {

--- a/docs/kafka.md
+++ b/docs/kafka.md
@@ -20,10 +20,10 @@ These Kafka-specific properties, if used, must be specified at the global level:
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`kafka.zookeeper.connect`|ZooKeeper connect string for Kafka.|none; must be provided|
+|`kafka.bootstrap.servers`|Initial broker list for connecting to Kafka cluster.|none; must be provided|
 |`kafka.group.id`|Group ID for Kafka consumers. **Note:** This must be the same for all instances to avoid data duplication!|tranquility-kafka|
-|`consumer.numThreads`|The number of threads that will be made available to the Kafka consumer for fetching messages.|{numProcessors} - 1|
-|`commit.periodMillis`|The frequency with which consumer offsets will be committed to ZooKeeper to track processed messages.|15000|
+|`consumer.numThreads`|The number of Kafka consumer threads for fetching messages.|{numProcessors} - 1|
+|`commit.periodMillis`|The frequency with which consumer offsets will be committed to Kafka to track processed messages.|15000|
 |`kafka.*`|Any properties that begin with *kafka.* will be passed to the underlying Kafka consumer with the *kafka.* prefix removed. For example, if you set `kafka.consumer.id=myConsumer`, the Kafka consumer will be passed the property `consumer.id=myConsumer`. Note that Tranquility Kafka requires `auto.commit.enable` to be *false* and any attempt to set this property will be overridden. |none|
 
 These Kafka-specific properties, if used, may be specified either at the global level or at the dataSource level:

--- a/kafka/src/main/java/com/metamx/tranquility/kafka/Consumer.java
+++ b/kafka/src/main/java/com/metamx/tranquility/kafka/Consumer.java
@@ -34,6 +34,7 @@ import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.KafkaException;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -119,9 +120,13 @@ public class Consumer
           writerController.stop();
           Iterator<KafkaConsumer> consumerIterator = polledConsumers.iterator();
           while (consumerIterator.hasNext()) {
-              KafkaConsumer kafkaConsumer = consumerIterator.next();
+            KafkaConsumer kafkaConsumer = consumerIterator.next();
+            try {
               kafkaConsumer.commitSync();
-              consumerIterator.remove();
+            } catch (KafkaException e) {
+              log.error(e, "Failed to sync Kafka consumer commit");
+            }
+            consumerIterator.remove();
           }
         }
         finally {
@@ -158,9 +163,13 @@ public class Consumer
 
       Iterator<KafkaConsumer> consumerIterator = polledConsumers.iterator();
       while (consumerIterator.hasNext()) {
-          KafkaConsumer kafkaConsumer = consumerIterator.next();
+        KafkaConsumer kafkaConsumer = consumerIterator.next();
+        try {
           kafkaConsumer.commitSync();
-          consumerIterator.remove();
+        } catch (KafkaException e) {
+          log.error(e, "Failed to sync Kafka consumer commit");
+        }
+        consumerIterator.remove();
       }
 
       final long finishedTime = System.currentTimeMillis();

--- a/kafka/src/main/java/com/metamx/tranquility/kafka/Consumer.java
+++ b/kafka/src/main/java/com/metamx/tranquility/kafka/Consumer.java
@@ -16,7 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package com.metamx.tranquility.kafka;
+
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
@@ -26,31 +28,27 @@ import com.metamx.tranquility.kafka.model.MessageCounters;
 import com.metamx.tranquility.kafka.model.PropertiesBasedKafkaConfig;
 import com.metamx.tranquility.kafka.writer.WriterController;
 import io.druid.concurrent.Execs;
-import kafka.consumer.Consumer;
-import kafka.consumer.ConsumerConfig;
-import kafka.consumer.KafkaStream;
-import kafka.consumer.TopicFilter;
-import kafka.consumer.Whitelist;
-import kafka.javaapi.consumer.ConsumerConnector;
-import kafka.message.MessageAndMetadata;
 
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.Collections;
 import java.util.Properties;
+import java.util.regex.Pattern;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-/**
- * Spawns a number of threads to read messages from Kafka topics and write them by calling
- * WriterController.getWriter(topic).send(). Will periodically call WriterController.flushAll() and when this completes
- * will call ConsumerConnector.commitOffsets() to save the last written offset to ZooKeeper. This implementation
- * guarantees that any events in Kafka will be read at least once even in case of a failure condition but does not
- * guarantee that duplication will not occur.
- */
-public class KafkaConsumer
+public class Consumer
 {
   private static final Logger log = new Logger(KafkaConsumer.class);
 
@@ -58,28 +56,37 @@ public class KafkaConsumer
   private final Thread commitThread;
   private final AtomicBoolean shutdown = new AtomicBoolean();
 
-  // prevents reading the next event from Kafka while events are being flushed and offset is being committed to ZK
   private final ReentrantReadWriteLock commitLock = new ReentrantReadWriteLock();
 
-  private final ConsumerConnector consumerConnector;
-  private final TopicFilter topicFilter;
+  private final Pattern topicFilter;
   private final int numThreads;
   private final int commitMillis;
   private final WriterController writerController;
 
   private Map<String, MessageCounters> previousMessageCounters = new HashMap<>();
 
-  public KafkaConsumer(
+  private final Properties kafkaProperties;
+  private Set<KafkaConsumer> polledConsumers;
+  private Set<KafkaConsumer> consumerSet;
+
+  public Consumer(
       final PropertiesBasedKafkaConfig globalConfig,
       final Properties kafkaProperties,
       final Map<String, DataSourceConfig<PropertiesBasedKafkaConfig>> dataSourceConfigs,
       final WriterController writerController
   )
   {
-    this.consumerConnector = getConsumerConnector(kafkaProperties);
-    this.topicFilter = new Whitelist(buildTopicFilter(dataSourceConfigs));
+    this.kafkaProperties = (Properties) kafkaProperties.clone();;
+    Preconditions.checkState(
+        !kafkaProperties.getProperty("enable.auto.commit", "").equals("true"),
+        "autocommit must be off"
+    );
+    this.kafkaProperties.setProperty("enable.auto.commit", "false");
+    this.polledConsumers = Collections.synchronizedSet(new HashSet<KafkaConsumer>());
+    this.consumerSet = Collections.synchronizedSet(new HashSet<KafkaConsumer>());
+    this.topicFilter = Pattern.compile(buildTopicFilter(dataSourceConfigs));
 
-    log.info("Kafka topic filter [%s]", this.topicFilter);
+    log.info("Kafka topic filter [%s]", this.topicFilter.pattern());
 
     int defaultNumThreads = Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
     this.numThreads = globalConfig.getConsumerNumThreads() > 0
@@ -88,7 +95,7 @@ public class KafkaConsumer
 
     this.commitMillis = globalConfig.getCommitPeriodMillis();
     this.writerController = writerController;
-    this.consumerExec = Execs.multiThreaded(numThreads, "KafkaConsumer-%d");
+    this.consumerExec = Execs.multiThreaded(this.numThreads, "KafkaConsumer-%d");
     this.commitThread = new Thread(createCommitRunnable());
     this.commitThread.setName("KafkaConsumer-CommitThread");
     this.commitThread.setDaemon(true);
@@ -110,11 +117,18 @@ public class KafkaConsumer
         try {
           writerController.flushAll(); // try to flush the remaining events to Druid
           writerController.stop();
-          consumerConnector.commitOffsets(); // update commit offset
+          Iterator<KafkaConsumer> consumerIterator = polledConsumers.iterator();
+          while (consumerIterator.hasNext()) {
+              KafkaConsumer kafkaConsumer = consumerIterator.next();
+              kafkaConsumer.commitSync();
+              consumerIterator.remove();
+          }
         }
         finally {
+          for (KafkaConsumer consumer : consumerSet) {
+            consumer.close();
+          }
           commitLock.writeLock().unlock();
-          consumerConnector.shutdown();
           commitThread.interrupt();
           consumerExec.shutdownNow();
         }
@@ -141,7 +155,13 @@ public class KafkaConsumer
       final Map<String, MessageCounters> messageCounters = writerController.flushAll(); // blocks until complete
 
       final long commitStartTime = System.currentTimeMillis();
-      consumerConnector.commitOffsets();
+
+      Iterator<KafkaConsumer> consumerIterator = polledConsumers.iterator();
+      while (consumerIterator.hasNext()) {
+          KafkaConsumer kafkaConsumer = consumerIterator.next();
+          kafkaConsumer.commitSync();
+          consumerIterator.remove();
+      }
 
       final long finishedTime = System.currentTimeMillis();
       Map<String, MessageCounters> countsSinceLastCommit = new HashMap();
@@ -196,69 +216,63 @@ public class KafkaConsumer
     };
   }
 
-  private void startConsumers()
-  {
-    final List<KafkaStream<byte[], byte[]>> kafkaStreams = consumerConnector.createMessageStreamsByFilter(
-        topicFilter,
-        numThreads
-    );
-
-    for (final KafkaStream<byte[], byte[]> kafkaStream : kafkaStreams) {
-      consumerExec.submit(
-          new Runnable()
-          {
-            @Override
-            public void run()
-            {
-              try {
-                final Iterator<MessageAndMetadata<byte[], byte[]>> kafkaIterator = kafkaStream.iterator();
-
-                while (kafkaIterator.hasNext()) {
-                  if (Thread.currentThread().isInterrupted()) {
-                    throw new InterruptedException();
-                  }
-
-                  // Kafka consumer treats messages as consumed and updates in-memory last offset when the message
-                  // is returned by next(). In order to guarantee at-least-once message delivery, we need to a) set
-                  // autocommit enable to false so the consumer will not automatically commit offsets to Zookeeper, and
-                  // b) synchronize calls of kafkaIterator.next() with the commit thread so that we don't read messages
-                  // and then call consumerConnector.commitOffsets() before those messages have been flushed through
-                  // Tranquility into the indexing service.
-                  commitLock.readLock().lockInterruptibly();
-
-                  try {
-                    MessageAndMetadata<byte[], byte[]> data = kafkaIterator.next();
-                    writerController.getWriter(data.topic()).send(data.message());
-                  }
-                  finally {
-                    commitLock.readLock().unlock();
-                  }
-                }
-              }
-              catch (InterruptedException e) {
-                log.info("Consumer thread interrupted.");
-              }
-              catch (Throwable e) {
-                log.error(e, "Exception: ");
-                throw Throwables.propagate(e);
-              }
-              finally {
-                stop();
-              }
-            }
-          }
-      );
-    }
+  private class NoopConsumerRebalanceListener implements ConsumerRebalanceListener {
+    public void onPartitionsRevoked(Collection<TopicPartition> partitions) {}
+    public void onPartitionsAssigned(Collection<TopicPartition> partitions) {}
   }
 
-  private static ConsumerConnector getConsumerConnector(final Properties props)
+  private void startConsumers()
   {
-    props.setProperty("auto.commit.enable", "false");
+    consumerExec.submit(
+        new Runnable()
+        {
+          @Override
+          public void run()
+          {
+            try {
+              KafkaConsumer<String, String> kafkaConsumer = new KafkaConsumer<>(kafkaProperties);
+              kafkaConsumer.subscribe(topicFilter, new NoopConsumerRebalanceListener());
+              consumerSet.add(kafkaConsumer);
 
-    final ConsumerConfig config = new ConsumerConfig(props);
-    Preconditions.checkState(!config.autoCommitEnable(), "autocommit must be off");
+              while(true) {
+                if (Thread.currentThread().isInterrupted()) {
+                  throw new InterruptedException();
+                }
 
-    return Consumer.createJavaConsumerConnector(config);
+                // In order to guarantee at-least-once message delivery, we need to a) set autocommit enable to 
+                // false so the consumer will not automatically commit offsets to Kafka, and b) synchronize calls of 
+                // kafkaConsumer.poll() with the commit thread so that we don't read messages and then call 
+                // kafkaConsumer.commitSync() before those messages have been flushed through Tranquility into 
+                // the indexing service.
+                commitLock.readLock().lockInterruptibly();
+
+                try {
+                  ConsumerRecords<String, String> records = kafkaConsumer.poll(100);
+                  for (ConsumerRecord<String, String> record : records) {
+                    writerController.getWriter(record.topic()).send(record.value().getBytes());
+                  }
+                  if (!records.isEmpty()) {
+                    polledConsumers.add(kafkaConsumer);
+                  }
+                }
+                finally {
+                  commitLock.readLock().unlock();
+                }
+              }
+            }
+            catch (InterruptedException e) {
+              log.info("Consumer thread interrupted.");
+            }
+            catch (Throwable e) {
+              log.error(e, "Exception: ");
+              throw Throwables.propagate(e);
+            }
+            finally {
+              stop();
+            }
+          }
+        }
+    );
   }
 
   private static String buildTopicFilter(Map<String, DataSourceConfig<PropertiesBasedKafkaConfig>> dataSourceConfigs)

--- a/kafka/src/main/java/com/metamx/tranquility/kafka/KafkaMain.java
+++ b/kafka/src/main/java/com/metamx/tranquility/kafka/KafkaMain.java
@@ -109,18 +109,10 @@ public class KafkaMain
 
     // set the critical Kafka configs again from TranquilityKafkaConfig so it picks up the defaults
     kafkaProperties.setProperty("group.id", globalConfig.getKafkaGroupId());
-    kafkaProperties.setProperty("zookeeper.connect", globalConfig.getKafkaZookeeperConnect());
-    if (kafkaProperties.setProperty(
-        "zookeeper.session.timeout.ms",
-        Long.toString(globalConfig.zookeeperTimeout().toStandardDuration().getMillis())
-    ) != null) {
-      throw new IllegalArgumentException(
-          "Set zookeeper.timeout instead of setting kafka.zookeeper.session.timeout.ms"
-      );
-    }
+    kafkaProperties.setProperty("bootstrap.servers", globalConfig.getKafkaBootstrapServers());
 
     final WriterController writerController = new WriterController(dataSourceConfigs);
-    final KafkaConsumer kafkaConsumer = new KafkaConsumer(
+    final Consumer consumer = new Consumer(
         globalConfig,
         kafkaProperties,
         dataSourceConfigs,
@@ -128,7 +120,7 @@ public class KafkaMain
     );
 
     try {
-      kafkaConsumer.start();
+      consumer.start();
     }
     catch (Throwable t) {
       log.error(t, "Error while starting up. Exiting.");
@@ -143,12 +135,12 @@ public class KafkaMain
               public void run()
               {
                 log.info("Initiating shutdown...");
-                kafkaConsumer.stop();
+                consumer.stop();
               }
             }
         )
     );
 
-    kafkaConsumer.join();
+    consumer.join();
   }
 }

--- a/kafka/src/main/java/com/metamx/tranquility/kafka/model/PropertiesBasedKafkaConfig.java
+++ b/kafka/src/main/java/com/metamx/tranquility/kafka/model/PropertiesBasedKafkaConfig.java
@@ -34,7 +34,7 @@ public abstract class PropertiesBasedKafkaConfig extends PropertiesBasedConfig
     super(
         ImmutableSet.of(
             "kafka.group.id",
-            "kafka.zookeeper.connect",
+            "kafka.bootstrap.servers",
             "consumer.numThreads",
             "commit.periodMillis"
         )
@@ -45,8 +45,8 @@ public abstract class PropertiesBasedKafkaConfig extends PropertiesBasedConfig
   @Default("tranquility-kafka")
   public abstract String getKafkaGroupId();
 
-  @Config("kafka.zookeeper.connect")
-  public abstract String getKafkaZookeeperConnect();
+  @Config("kafka.bootstrap.servers")
+  public abstract String getKafkaBootstrapServers();
 
   @Config("consumer.numThreads")
   @Default("-1")
@@ -75,4 +75,5 @@ public abstract class PropertiesBasedKafkaConfig extends PropertiesBasedConfig
   @Config("reportParseExceptions")
   @Default("false")
   public abstract Boolean reportParseExceptions();
+
 }


### PR DESCRIPTION
Updates Kafka module to use newer [0.9.0.1 Kafka Consumer API](https://kafka.apache.org/090/javadoc/index.html?org/apache/kafka/clients/consumer/KafkaConsumer.html). Configuration files used with the module will need to include a `kafka.bootstrap.servers` option instead of `kafka.zookeeper.connect` per the [0.9.0.1 consumer configs](https://kafka.apache.org/090/documentation.html#newconsumerconfigs). Consumer offsets will be committed to the `__consumer_offsets` Kafka topic instead of Zookeeper znodes. 

To test the Kafka module, run `test-only com.metamx.tranquility.kafka.KafkaConsumerTest` from the sbt prompt.

Note, this will break previously supported usage with older < 0.8.X brokers. 